### PR TITLE
ci(jenkins): fix nodejs version to 16.13.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ sbCtx = pipeline.createContext([
             // ],
             [
                 name: "nodejs",
-                image: "node:16-alpine",
+                image: "node:16.13.2-alpine",
                 ttyEnabled: true,
                 command: "cat",
             ],


### PR DESCRIPTION
created #77 for investigating

Signed-off-by: Olivier Albertini <olivier.albertini@montreal.ca>


J'ai essayé différentes versions de nodejs et c'est la seule qui marche pour l'instant (que j'ai trouvé). Ça permet de régler le déploiement, en attendant de trouver pourquoi les nouvelles ne marchent pas