### PR TITLE
fix(dropdown-menu): fix checkbox input won't change state on click.

### DIFF
--- a/projects/angular-ui/src/lib/dropdown-menu/dropdown-menu.component.spec.ts
+++ b/projects/angular-ui/src/lib/dropdown-menu/dropdown-menu.component.spec.ts
@@ -10,7 +10,8 @@ import { By } from '@angular/platform-browser';
 import { OverlayModule } from '@angular/cdk/overlay';
 import {
   TestButtonMenuHostComponent,
-  TestDropdownMenuHostComponent
+  TestDropdownMenuHostComponent,
+  TestDropdownWithInputsHostComponent
 } from './tests/dropdown-menu.hostcomponent.spec';
 import {
   BaoDropdownMenuComponent,
@@ -18,7 +19,11 @@ import {
   BaoDropdownMenuTrigger,
   BaoDropdownMenuItemLabel
 } from './dropdown-menu.component';
-import { BaoIconComponent } from 'angular-ui';
+import {
+  BaoIconComponent,
+  BaoCheckboxComponent,
+  BaoRadioButtonComponent
+} from 'angular-ui';
 
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 describe('BaoDropdownMenuComponent', () => {
@@ -126,6 +131,96 @@ describe('BaoDropdownMenuComponent', () => {
       expect(
         buttonDebugElement.nativeNode.attributes['aria-controls'].value
       ).toBe(dropdownMenuDebugElement.nativeNode.id);
+    });
+  });
+  describe('Dropdown menu items with inputs', () => {
+    let fixture: ComponentFixture<TestDropdownWithInputsHostComponent>;
+    let menuItemsDebugElement: DebugElement[];
+    let checkboxDebugElement: DebugElement;
+    let radioDebugElement: DebugElement;
+
+    beforeEach(
+      waitForAsync(() => {
+        TestBed.configureTestingModule({
+          declarations: [
+            BaoDropdownMenuComponent,
+            BaoDropdownMenuTrigger,
+            BaoDropdownMenuItem,
+            BaoDropdownMenuItemLabel,
+            TestDropdownWithInputsHostComponent,
+            BaoCheckboxComponent,
+            BaoRadioButtonComponent
+          ],
+          imports: [OverlayModule]
+        });
+        return TestBed.compileComponents();
+      })
+    );
+    beforeEach(() => {
+      fixture = TestBed.createComponent(TestDropdownWithInputsHostComponent);
+      fixture.detectChanges();
+      menuItemsDebugElement = fixture.debugElement.queryAll(
+        By.css('.bao-dropdown-menu-item')
+      );
+      checkboxDebugElement = fixture.debugElement.query(
+        By.css('.bao-checkbox')
+      );
+      radioDebugElement = fixture.debugElement.query(
+        By.css('.bao-radio-button')
+      );
+    });
+
+    it('click on checkbox or associated menu item should change its state', () => {
+      expect(
+        checkboxDebugElement.nativeNode.classList.contains(
+          'bao-checkbox-checked'
+        )
+      ).toBe(false);
+      checkboxDebugElement.nativeNode.firstElementChild.click();
+      fixture.detectChanges();
+      expect(
+        checkboxDebugElement.nativeNode.classList.contains(
+          'bao-checkbox-checked'
+        )
+      ).toBe(true);
+      expect(
+        checkboxDebugElement.nativeNode.firstElementChild.attributes[
+          'aria-checked'
+        ].value
+      ).toBe('true');
+      menuItemsDebugElement[0].nativeElement.click();
+      fixture.detectChanges();
+      expect(
+        checkboxDebugElement.nativeNode.classList.contains(
+          'bao-checkbox-checked'
+        )
+      ).toBe(false);
+      expect(
+        checkboxDebugElement.nativeNode.firstElementChild.attributes[
+          'aria-checked'
+        ].value
+      ).toBe('false');
+    });
+    it('click on radio button or associated menu item should change its state', () => {
+      expect(
+        radioDebugElement.nativeNode.classList.contains(
+          'bao-radio-button-checked'
+        )
+      ).toBe(false);
+      radioDebugElement.nativeNode.firstElementChild.click();
+      fixture.detectChanges();
+      expect(
+        radioDebugElement.nativeNode.classList.contains(
+          'bao-radio-button-checked'
+        )
+      ).toBe(true);
+      menuItemsDebugElement[1].nativeElement.click();
+      fixture.detectChanges();
+      expect(
+        radioDebugElement.nativeNode.classList.contains(
+          'bao-radio-button-checked'
+        )
+      ).toBe(true);
     });
   });
 });

--- a/projects/angular-ui/src/lib/dropdown-menu/dropdown-menu.component.ts
+++ b/projects/angular-ui/src/lib/dropdown-menu/dropdown-menu.component.ts
@@ -67,12 +67,15 @@ export class BaoDropdownMenuItem implements AfterViewInit, OnChanges {
     }
   }
 
-  @HostListener('click')
-  onClick() {
+  @HostListener('click', ['$event.target'])
+  onClick(el: HTMLElement) {
     if (this.nativeElement.attributes['href']) {
       this._parent.setNavigationAttribute(this.nativeElement);
     }
-    this.propagateClick();
+    // Prevent double-click on checkbox input that undoes the toggle
+    if (!el.classList.contains('bao-checkbox-content-container')) {
+      this.propagateClick();
+    }
   }
 
   @HostListener('window:keydown.enter')

--- a/projects/angular-ui/src/lib/dropdown-menu/tests/dropdown-menu.hostcomponent.spec.ts
+++ b/projects/angular-ui/src/lib/dropdown-menu/tests/dropdown-menu.hostcomponent.spec.ts
@@ -30,3 +30,18 @@ export class TestButtonMenuHostComponent {}
 export class TestDropdownMenuHostComponent {
   disabled: boolean;
 }
+@Component({
+  template: `
+    <bao-dropdown-menu>
+      <a bao-dropdown-menu-item>
+        <bao-checkbox></bao-checkbox>
+        <bao-dropdown-menu-item-label>Libellé</bao-dropdown-menu-item-label>
+      </a>
+      <a bao-dropdown-menu-item>
+        <bao-radio-button></bao-radio-button>
+        <bao-dropdown-menu-item-label>Libellé</bao-dropdown-menu-item-label>
+      </a>
+    </bao-dropdown-menu>
+  `
+})
+export class TestDropdownWithInputsHostComponent {}


### PR DESCRIPTION
Il est maintenant possible de changer l'état de la checkbox en cliquant directement dessus, ou en cliquant n'importe où ailleurs sur l'item du menu correspondant.