### PR TITLE
fix(dropdown-menu): fix menu display when it's used as a child component

### DIFF
--- a/projects/angular-ui/src/lib/dropdown-menu/dropdown-menu.component.scss
+++ b/projects/angular-ui/src/lib/dropdown-menu/dropdown-menu.component.scss
@@ -6,6 +6,10 @@
 $overlay-min-width: 16rem !default;
 $overlay-max-width: 32rem !default;
 
+.bao-dropdown-menu-container.bao-dropdown-menu-closed {
+  display: none;
+}
+
 .bao-dropdown-menu {
   min-width: $overlay-min-width;
   max-width: $overlay-max-width;
@@ -15,9 +19,6 @@ $overlay-max-width: 32rem !default;
   border-radius: 0.25rem;
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
-  &.bao-dropdown-menu-closed {
-    display: none;
-  }
   .bao-overlay-transparent-backdrop {
     background-color: $transparent;
     display: none;

--- a/projects/angular-ui/src/lib/dropdown-menu/dropdown-menu.component.spec.ts
+++ b/projects/angular-ui/src/lib/dropdown-menu/dropdown-menu.component.spec.ts
@@ -56,7 +56,7 @@ describe('BaoDropdownMenuComponent', () => {
       testMenuComponent = fixtureMenu.componentInstance;
       fixtureMenu.detectChanges();
       dropdownMenuDebugElement = fixtureMenu.debugElement.query(
-        By.css('.bao-dropdown-menu')
+        By.css('.bao-dropdown-menu-container')
       );
       listItemDebugElement =
         dropdownMenuDebugElement.nativeNode.children[0].children;
@@ -64,7 +64,7 @@ describe('BaoDropdownMenuComponent', () => {
     it('should apply appropriate css class when menu is initially closed ', () => {
       expect(
         dropdownMenuDebugElement.nativeNode.classList.contains(
-          'bao-dropdown-menu'
+          'bao-dropdown-menu-container'
         )
       ).toBe(true);
       expect(
@@ -117,7 +117,7 @@ describe('BaoDropdownMenuComponent', () => {
       fixtureButton.detectChanges();
       buttonDebugElement = fixtureButton.debugElement.query(By.css('button'));
       dropdownMenuDebugElement = fixtureButton.debugElement.query(
-        By.css('.bao-dropdown-menu')
+        By.css('.bao-dropdown-menu-container')
       );
     });
 

--- a/projects/angular-ui/src/lib/dropdown-menu/dropdown-menu.component.ts
+++ b/projects/angular-ui/src/lib/dropdown-menu/dropdown-menu.component.ts
@@ -177,7 +177,7 @@ export class BaoDropdownMenuItem implements AfterViewInit, OnChanges {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    class: 'bao-dropdown-menu',
+    class: 'bao-dropdown-menu-container',
     '[class.bao-overlay-transparent-backdrop]': 'isOpen===false',
     '[class.bao-dropdown-menu-closed]': 'isOpen===false',
     '[attr.aria-expanded]': 'isOpen'


### PR DESCRIPTION
La composante doit être utilisée dans une application ou une autre composante parent pour tester le fix, le bug n'apparaît pas lorsque la composante est utilisée seule.
Voir le screenshot dans l'issue #102 pour voir le glitch lorsque la composante est utilisée dans la composante Fichier (qui est encore en cours de développement).

![dropdown_menu_good](https://user-images.githubusercontent.com/33531625/204599648-9e5d377d-5b94-4b2f-aad6-54b4a58e5ba3.PNG)
