### PR TITLE
feat(file-input): add file-input component. close #88.

### DIFF
--- a/projects/angular-ui/src/lib/bao.module.ts
+++ b/projects/angular-ui/src/lib/bao.module.ts
@@ -21,6 +21,7 @@ import { BaoTabsModule } from './tabs';
 import { BaoModalModule } from './modal/module';
 import { BaoHyperlinkModule } from './hyperlink';
 import { BaoDropdownMenuModule } from './dropdown-menu';
+import { BaoFileModule } from './file/module';
 
 @NgModule({
   imports: [
@@ -47,7 +48,8 @@ import { BaoDropdownMenuModule } from './dropdown-menu';
     BaoTabsModule,
     BaoModalModule,
     BaoHyperlinkModule,
-    BaoDropdownMenuModule
+    BaoDropdownMenuModule,
+    BaoFileModule
     // TODO: reactivate once component does not depend on global css BaoBadgeModule,
     // TODO: reactivate once component does not depend on global css BaoSnackBarModule,
   ]

--- a/projects/angular-ui/src/lib/common-components/label-text/labelText.component.scss
+++ b/projects/angular-ui/src/lib/common-components/label-text/labelText.component.scss
@@ -6,9 +6,10 @@
   font-weight: $font-weight-bold;
   line-height: 1.5em;
   font-size: 1rem;
-  margin-bottom: 0;
+  margin-bottom: 0.5rem;
 
   span {
     color: $negative-reversed;
+    margin: 0;
   }
 }

--- a/projects/angular-ui/src/lib/common-components/label-text/labelText.component.ts
+++ b/projects/angular-ui/src/lib/common-components/label-text/labelText.component.ts
@@ -8,8 +8,7 @@ import { Component, Input, ViewEncapsulation } from '@angular/core';
 @Component({
   selector: 'bao-label, [bao-label]',
   encapsulation: ViewEncapsulation.None,
-  template:
-    '<div class="bao-label"><ng-content></ng-content><span *ngIf="required">&nbsp;*</span></div>',
+  template: '<ng-content></ng-content><span *ngIf="required">&nbsp;*</span>',
   styleUrls: ['./labelText.component.scss'],
   host: { class: 'bao-label' }
 })

--- a/projects/angular-ui/src/lib/common-components/module.ts
+++ b/projects/angular-ui/src/lib/common-components/module.ts
@@ -5,12 +5,10 @@
  */
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import {
-  BaoErrorTextComponent,
-  BaoGuidingTextComponent,
-  BaoLabelTextComponent,
-  BaoTitleTextComponent
-} from '.';
+import { BaoErrorTextComponent } from './error-text/errorText.component';
+import { BaoGuidingTextComponent } from './guiding-text/guidingText.component';
+import { BaoLabelTextComponent } from './label-text/labelText.component';
+import { BaoTitleTextComponent } from './title-text/titleText.component';
 
 const DIRECTIVES = [
   BaoErrorTextComponent,

--- a/projects/angular-ui/src/lib/core/_typography.scss
+++ b/projects/angular-ui/src/lib/core/_typography.scss
@@ -59,6 +59,12 @@ $font-weight-medium-bold: 600;
   line-height: 1rem;
 }
 
+@mixin typo-interface-xsmall {
+  font-weight: $font-weight-normal;
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
 @mixin typo-paragraph-large {
   font-weight: $font-weight-normal;
   font-size: 1.25rem;

--- a/projects/angular-ui/src/lib/dropdown-menu/dropdown-menu.component.ts
+++ b/projects/angular-ui/src/lib/dropdown-menu/dropdown-menu.component.ts
@@ -497,6 +497,13 @@ export class BaoDropdownMenuTrigger implements AfterViewInit, OnDestroy {
             originY: 'top',
             overlayX: 'start',
             overlayY: 'bottom'
+          } as ConnectedPosition,
+          {
+            // top-right of the overlay is connected to bottom-left of the origin;
+            originX: 'start',
+            originY: 'bottom',
+            overlayX: 'end',
+            overlayY: 'top'
           } as ConnectedPosition
         ]),
       backdropClass: 'bao-overlay-transparent-backdrop',

--- a/projects/angular-ui/src/lib/file/file-input.component.html
+++ b/projects/angular-ui/src/lib/file/file-input.component.html
@@ -1,0 +1,46 @@
+<label bao-label [required]="required" [for]="inputId">{{ label }}</label>
+<ng-content select="bao-guiding-text"></ng-content>
+<div
+  baoFileDrop
+  class="file-drop-zone"
+  (fileDrop)="uploadFile($event)"
+  #dropzone
+>
+  <button
+    bao-button
+    type="button"
+    displayType="utility"
+    level="secondary"
+    [disabled]="disabled"
+    (click)="uploader.click()"
+    aria-hidden="true"
+    tabIndex="-1"
+  >
+    {{ intl.dropzoneButtonLabel }}
+  </button>
+  <input
+    [id]="inputId"
+    type="file"
+    class="sr-only"
+    [disabled]="disabled"
+    (change)="uploadFile($event.target.files[0])"
+    #uploader
+  />
+  <ng-container
+    ><div #ref>
+      <ng-content select="bao-file-dropzone-instructions"></ng-content></div
+  ></ng-container>
+  <ng-container *ngIf="ref.childNodes.length === 0"
+    ><bao-file-dropzone-instructions>{{
+      intl.defaultDropzoneInstructions
+    }}</bao-file-dropzone-instructions></ng-container
+  >
+</div>
+<bao-error *ngIf="isFileTooBig">
+  {{ intl.fileTooBigErrorMessage }}
+</bao-error>
+<bao-error *ngIf="isFileTypeInvalid">
+  {{ intl.invalidFileTypeErrorMessage }}
+</bao-error>
+<ng-content select="bao-error"></ng-content>
+<ng-content></ng-content>

--- a/projects/angular-ui/src/lib/file/file-input.component.scss
+++ b/projects/angular-ui/src/lib/file/file-input.component.scss
@@ -1,0 +1,72 @@
+@import '../core/colors';
+@import '../core/typography';
+@import '../core/shadows';
+
+bao-file-input {
+  width: 100%;
+  display: inline-flex;
+  flex-direction: column;
+  > ul {
+    padding: 0;
+    margin: 0;
+  }
+  & .bao-label {
+    > span {
+      font-size: inherit;
+      font-weight: inherit;
+    }
+  }
+  &.bao-file-label-small {
+    label {
+      @include typo-interface-small-bold;
+    }
+  }
+  &.bao-file-label-medium {
+    label {
+      @include typo-interface-medium-bold;
+    }
+  }
+  .bao-guiding-text {
+    margin-bottom: 0.5rem;
+  }
+  .file-drop-zone {
+    padding: 0.5rem;
+    background-color: $neutral-ground;
+    border-radius: 0.25rem;
+    border-style: dashed;
+    border-color: $neutral-stroke;
+    border-width: 1px;
+    display: inline-flex;
+    align-items: center;
+    &:focus-within.dropzone-focus {
+      box-shadow: 0 0 0 0.1875rem $highlight-focus;
+      background-color: $highlight-light;
+    }
+    > .bao-button {
+      margin-right: 0.5rem;
+    }
+    &.drag-over {
+      background-color: $highlight-light;
+      border-color: $action;
+      cursor: drag;
+      > .bao-button {
+        background-color: $highlight-light;
+      }
+    }
+  }
+  &.bao-file-input-disabled {
+    .file-drop-zone {
+      background-color: $neutral-underground;
+      border-color: $neutral-stroke;
+      .bao-button {
+        background-color: $neutral-underground;
+        &:hover {
+          background-color: $neutral-underground;
+        }
+      }
+    }
+  }
+  .bao-error {
+    margin-top: 0.5rem;
+  }
+}

--- a/projects/angular-ui/src/lib/file/file-input.component.spec.ts
+++ b/projects/angular-ui/src/lib/file/file-input.component.spec.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2023 Ville de Montreal. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE file in the project root for full license information.
+ */
+
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { TestFileInputHostComponent } from './tests/file-input.hostcomponent.spec';
+import {
+  BaoFileInputComponent,
+  BaoFileDropDirective,
+  BaoFileDropzoneIntructions
+} from './file-input.component';
+import { BaoFileIntl, BaoFileIntlEnglish } from './file-intl';
+import { BaoIconComponent } from '../icon';
+import { BaoButtonComponent } from '../button';
+import {
+  BaoGuidingTextComponent,
+  BaoLabelTextComponent,
+  BaoErrorTextComponent
+} from '../common-components';
+
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+describe('BaoFileInputComponent', () => {
+  describe('Primary', () => {
+    let testComponent: TestFileInputHostComponent;
+    let fixtureFileInput: ComponentFixture<TestFileInputHostComponent>;
+    let fileInputDebugElement: DebugElement;
+
+    beforeEach(
+      waitForAsync(() => {
+        TestBed.configureTestingModule({
+          declarations: [
+            BaoFileInputComponent,
+            BaoIconComponent,
+            BaoGuidingTextComponent,
+            BaoFileDropDirective,
+            BaoLabelTextComponent,
+            BaoErrorTextComponent,
+            BaoFileDropzoneIntructions,
+            BaoButtonComponent,
+            TestFileInputHostComponent
+          ],
+          imports: [OverlayModule],
+          providers: [BaoFileIntl]
+        });
+        return TestBed.compileComponents();
+      })
+    );
+
+    beforeEach(() => {
+      fixtureFileInput = TestBed.createComponent(TestFileInputHostComponent);
+      testComponent = fixtureFileInput.componentInstance;
+      fixtureFileInput.detectChanges();
+      fileInputDebugElement = fixtureFileInput.debugElement.query(
+        By.css('bao-file-input')
+      );
+    });
+    it('should create', () => {
+      expect(testComponent).toBeTruthy();
+    });
+    it('should apply appropriate css class based on inputs', () => {
+      // Default class
+      expect(
+        fileInputDebugElement.nativeNode.classList.contains('bao-file-input')
+      ).toBe(true);
+      // Size input
+      testComponent.size = 'small';
+      fixtureFileInput.detectChanges();
+      expect(
+        fileInputDebugElement.nativeNode.classList.contains(
+          'bao-file-label-small'
+        )
+      ).toBe(true);
+
+      testComponent.size = 'medium';
+      fixtureFileInput.detectChanges();
+      expect(
+        fileInputDebugElement.nativeNode.classList.contains(
+          'bao-file-label-medium'
+        )
+      ).toBe(true);
+      // Disabled input
+      testComponent.disabled = true;
+      fixtureFileInput.detectChanges();
+      expect(
+        fileInputDebugElement.nativeNode.classList.contains(
+          'bao-file-input-disabled'
+        )
+      ).toBe(true);
+    });
+    it('should set aria attributes on helper text', () => {
+      const helperText = fixtureFileInput.debugElement.queryAll(
+        By.css('bao-guiding-text')
+      );
+      const dropZone = fixtureFileInput.debugElement.queryAll(
+        By.css('.file-drop-zone')
+      );
+      expect(helperText.length).toBe(1);
+      expect(dropZone.length).toBe(1);
+      const innerHelperText = helperText[0].nativeNode.firstElementChild;
+      const inputElement = dropZone[0].nativeNode.children.item(1);
+      expect(inputElement.attributes['aria-describedby']).toBeDefined();
+      expect(inputElement.attributes['aria-describedby'].value).toBe(
+        innerHelperText.id
+      );
+    });
+    it('should display text in french by default', () => {
+      const buttonElement = fixtureFileInput.debugElement.queryAll(
+        By.css('.bao-button')
+      );
+      expect(buttonElement.length).toBe(1);
+      const dropzoneInstructions = fixtureFileInput.debugElement.queryAll(
+        By.css('.bao-file-dropzone-instructions')
+      );
+      expect(dropzoneInstructions.length).toBe(1);
+      expect(buttonElement[0].nativeNode.innerText).toBe('Parcourir');
+      expect(dropzoneInstructions[0].nativeNode.innerText).toBe(
+        'ou déposer votre fichier ici'
+      );
+    });
+  });
+  describe('With english text', () => {
+    let testComponent: TestFileInputHostComponent;
+    let fixtureFileInput: ComponentFixture<TestFileInputHostComponent>;
+
+    beforeEach(
+      waitForAsync(() => {
+        TestBed.configureTestingModule({
+          declarations: [
+            BaoFileInputComponent,
+            BaoIconComponent,
+            BaoGuidingTextComponent,
+            BaoFileDropDirective,
+            BaoLabelTextComponent,
+            BaoErrorTextComponent,
+            BaoFileDropzoneIntructions,
+            BaoButtonComponent,
+            TestFileInputHostComponent
+          ],
+          imports: [OverlayModule],
+          providers: [{ provide: BaoFileIntl, useClass: BaoFileIntlEnglish }]
+        });
+        return TestBed.compileComponents();
+      })
+    );
+
+    beforeEach(() => {
+      fixtureFileInput = TestBed.createComponent(TestFileInputHostComponent);
+      testComponent = fixtureFileInput.componentInstance;
+      fixtureFileInput.detectChanges();
+    });
+    it('should create', () => {
+      expect(testComponent).toBeTruthy();
+    });
+    it('should display text in english', () => {
+      const buttonElement = fixtureFileInput.debugElement.queryAll(
+        By.css('.bao-button')
+      );
+      expect(buttonElement.length).toBe(1);
+      const dropzoneInstructions = fixtureFileInput.debugElement.queryAll(
+        By.css('.bao-file-dropzone-instructions')
+      );
+      expect(dropzoneInstructions.length).toBe(1);
+      expect(buttonElement[0].nativeNode.innerText).toBe('Browse');
+      expect(dropzoneInstructions[0].nativeNode.innerText).toBe(
+        'or drop your file here'
+      );
+    });
+  });
+});

--- a/projects/angular-ui/src/lib/file/file-input.component.ts
+++ b/projects/angular-ui/src/lib/file/file-input.component.ts
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) 2023 Ville de Montreal. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE file in the project root for full license information.
+ */
+
+import {
+  AfterContentInit,
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  ContentChildren,
+  Directive,
+  ElementRef,
+  EventEmitter,
+  forwardRef,
+  HostListener,
+  Input,
+  OnDestroy,
+  Output,
+  QueryList,
+  Renderer2,
+  ViewChild,
+  ViewChildren,
+  ViewEncapsulation
+} from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { BaoErrorTextComponent } from '../common-components';
+import { Subscription } from 'rxjs';
+import { BaoFileIntl } from './file-intl';
+import { BaoFilePreviewComponent } from './file-preview.component';
+
+/**
+ * Unique number to generate a unique ID
+ */
+let fileInputUniqueId = 0;
+let fileTextUniqueId = 0;
+
+@Component({
+  selector: 'bao-file-input, [bao-file-input]',
+  templateUrl: './file-input.component.html',
+  styleUrls: ['./file-input.component.scss'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      // tslint:disable-next-line:no-forward-ref
+      useExisting: forwardRef(() => BaoFileInputComponent),
+      multi: true
+    }
+  ],
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    class: 'bao-file-input',
+    '[class.bao-file-label-small]': 'size === "small"',
+    '[class.bao-file-label-medium]': 'size === "medium"',
+    '[class.bao-file-input-disabled]': 'disabled'
+  }
+})
+export class BaoFileInputComponent
+  implements AfterContentInit, AfterViewInit, OnDestroy, ControlValueAccessor
+{
+  /**
+   * Id of the file input field
+   */
+  @Input('id') public inputId?: string;
+
+  /**
+   * Label of field to be displayed above
+   */
+  @Input() public label: string;
+
+  /**
+   * Size of the file input label
+   */
+  @Input() public size: 'small' | 'medium' = 'medium';
+
+  /**
+   * Maximum size accepted for uploaded files
+   */
+  @Input() public maximalFileSize = -1;
+
+  /**
+   * Accepted types of files
+   */
+  @Input() public acceptedMIMETypes: string[] = [];
+
+  /**
+   * Is field required
+   */
+  @Input() public required? = false;
+
+  /**
+   * Is field disabled
+   */
+  @Input() public disabled? = false;
+
+  /**
+   * File selected to be uploaded
+   */
+  @Output() public uploadedFile: EventEmitter<File> = new EventEmitter<File>();
+
+  /**
+   * List of files that have been uploaded so far
+   */
+  @ContentChildren(BaoFilePreviewComponent, { descendants: true })
+  private _files: QueryList<BaoFilePreviewComponent>;
+
+  /**
+   * Form errors when component is used in a form
+   */
+  @ContentChildren(BaoErrorTextComponent, { descendants: true })
+  private _errorForm: QueryList<BaoErrorTextComponent>;
+
+  /**
+   * Error texts
+   */
+  @ViewChildren(BaoErrorTextComponent)
+  private _errorTexts: QueryList<BaoErrorTextComponent>;
+
+  /**
+   * File input that triggers uploading when clicked
+   */
+  @ViewChild('uploader', { static: false }) private uploader: ElementRef;
+
+  @ViewChild('dropzone', { static: false })
+  private dropzoneElement: ElementRef<HTMLElement>;
+
+  public insertDefaultInstructions = false;
+  public isFileTooBig = false;
+  public isFileTypeInvalid = false;
+  private _value: File[];
+  private _intlChanges: Subscription;
+  private _helperTextId: string;
+
+  constructor(
+    public intl: BaoFileIntl,
+    private elementRef: ElementRef<HTMLElement>,
+    private renderer: Renderer2,
+    private cdr: ChangeDetectorRef
+  ) {
+    this._intlChanges = intl.changes.subscribe(() => this.cdr.markForCheck());
+  }
+
+  get nativeElement(): HTMLElement {
+    return this.elementRef.nativeElement;
+  }
+
+  @HostListener('window:keyup.enter')
+  enterKeyEvent() {
+    if (document.activeElement.id === this.inputId) {
+      document.getElementById(this.inputId).click();
+    }
+  }
+
+  @HostListener('window:keyup.tab')
+  tabKeyEvent() {
+    if (document.activeElement.id === this.inputId) {
+      this.renderer.addClass(
+        this.dropzoneElement.nativeElement,
+        'dropzone-focus'
+      );
+    }
+  }
+
+  @HostListener('window:keyup.shift.tab')
+  shiftTabKeyEvent() {
+    if (document.activeElement.id === this.inputId) {
+      this.renderer.addClass(
+        this.dropzoneElement.nativeElement,
+        'dropzone-focus'
+      );
+    }
+  }
+
+  public ngAfterContentInit(): void {
+    this._errorForm.changes.subscribe(() => this.setErrorTextsAttribute());
+    if (!this.inputId) {
+      this.inputId = `file-input-${fileInputUniqueId++}`;
+    }
+    // If no content was added for dropzone instructions, add default text.
+    const dropzoneElement = Array.from(this.nativeElement.children).find(
+      (el: HTMLElement) => el.className === 'file-drop-zone'
+    );
+    if (
+      !Array.from(dropzoneElement.children).find(
+        el => el.localName === 'bao-file-dropzone-instructions'
+      )
+    ) {
+      this.insertDefaultInstructions = true;
+    }
+    this.setDescribedByAttribute();
+    this._files.changes.subscribe(
+      (files: QueryList<BaoFilePreviewComponent>) => {
+        const filesList: File[] = files.map(
+          (el: BaoFilePreviewComponent) => el.file
+        );
+        this.setValue(filesList);
+      }
+    );
+  }
+
+  public ngAfterViewInit(): void {
+    this._errorTexts.changes.subscribe(() => this.setErrorTextsAttribute());
+  }
+
+  public ngOnDestroy(): void {
+    this._intlChanges.unsubscribe();
+  }
+
+  /**
+   * Implements ControlValueAccessor interface
+   */
+  public writeValue(obj: any): void {
+    this._value = obj;
+  }
+  /**
+   * Implements ControlValueAccessor interface
+   */
+  public registerOnChange(fn: (value: any) => void): void {
+    this.propagateChange = fn;
+  }
+  /**
+   * Implements ControlValueAccessor interface
+   */
+  public registerOnTouched(fn: any): void {
+    this.propagateTouched = fn;
+  }
+  /**
+   * Implements ControlValueAccessor interface
+   */
+  public setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
+  }
+
+  public uploadFile(file: File) {
+    if (!this.disabled) {
+      this.isFileTypeInvalid = false;
+      this.isFileTooBig = false;
+      this.uploader.nativeElement.value = '';
+      if (this.maximalFileSize > 0 && file.size > this.maximalFileSize) {
+        this.isFileTooBig = true;
+      }
+      if (
+        this.acceptedMIMETypes.length > 0 &&
+        this.acceptedMIMETypes.indexOf(file.type) < 0
+      ) {
+        this.isFileTypeInvalid = true;
+      }
+      if (!this.isFileTooBig && !this.isFileTypeInvalid) {
+        this.uploadedFile.emit(file);
+      }
+    }
+  }
+
+  /**
+   * Saves the registerOnChange function so the component can call it whenever it wants.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
+  public propagateChange = (_: any) => {};
+
+  /**
+   * Saves the registerOnTouched function so the component can call it whenever it wants.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  public propagateTouched = () => {};
+
+  private setValue(value: File[]) {
+    this._value = value;
+    this.propagateChange(this._value);
+    this.propagateTouched();
+  }
+
+  private setDescribedByAttribute(): void {
+    const helperText = Array.from(this.nativeElement.children).find(
+      (el: HTMLElement) => el.localName === 'bao-guiding-text'
+    ).firstElementChild;
+    if (helperText) {
+      this._helperTextId = `bao-guiding-text-${fileTextUniqueId++}`;
+      this.renderer.setAttribute(helperText, 'id', this._helperTextId);
+      const inputElement = Array.from(this.nativeElement.children)
+        .find((el: HTMLElement) => el.className == 'file-drop-zone')
+        .children.item(1);
+      this.renderer.setAttribute(
+        inputElement,
+        'aria-describedby',
+        this._helperTextId
+      );
+    }
+  }
+
+  private setErrorTextsAttribute(): void {
+    const textsIds = [];
+    const errors = Array.from(this.nativeElement.children).filter(
+      (el: HTMLElement) => el.localName == 'bao-error'
+    );
+    errors.forEach((errorText: HTMLElement) => {
+      const errorTextId = `bao-error-${fileTextUniqueId++}`;
+      this.renderer.setAttribute(
+        errorText.firstElementChild,
+        'id',
+        errorTextId
+      );
+      textsIds.push(errorTextId);
+    });
+    const inputElement = Array.from(this.nativeElement.children)
+      .find((el: HTMLElement) => el.classList.contains('file-drop-zone'))
+      .children.item(1);
+    if (this._helperTextId) {
+      textsIds.unshift(this._helperTextId);
+    }
+    this.renderer.setAttribute(
+      inputElement,
+      'aria-describedby',
+      textsIds.join(' ')
+    );
+  }
+}
+
+@Directive({
+  selector: '[baoFileDrop]',
+  host: { '[class.drag-over]': '_isDragOver == true' }
+})
+export class BaoFileDropDirective {
+  @Output() public fileDrop: EventEmitter<File> = new EventEmitter<File>();
+  private _isDragOver = false;
+
+  @HostListener('dragover', ['$event'])
+  public onDragOver(event: DragEvent): void {
+    this.preventAndStop(event);
+    this._isDragOver = true;
+  }
+
+  @HostListener('dragleave', ['$event'])
+  public onDragLeave(event: DragEvent): void {
+    this.preventAndStop(event);
+    this._isDragOver = false;
+  }
+
+  @HostListener('drop', ['$event'])
+  public onDrop(event: DragEvent): void {
+    this.preventAndStop(event);
+    this._isDragOver = false;
+    const transfer = this.getDataTransfer(event);
+    this.fileDrop.emit(transfer.files[0]);
+  }
+
+  private preventAndStop(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  private getDataTransfer(event: DragEvent | any): DataTransfer {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return event.dataTransfer
+      ? event.dataTransfer
+      : event.originalEvent.dataTransfer;
+  }
+}
+
+@Directive({
+  selector: 'bao-file-dropzone-instructions, [bao-file-dropzone-instructions]',
+  host: {
+    class: 'bao-file-dropzone-instructions'
+  }
+})
+export class BaoFileDropzoneIntructions implements AfterContentInit {
+  constructor(
+    private renderer: Renderer2,
+    private elementRef: ElementRef<HTMLElement>
+  ) {}
+
+  get nativeElement(): HTMLElement {
+    return this.elementRef.nativeElement;
+  }
+
+  ngAfterContentInit(): void {
+    this.renderer.setAttribute(this.nativeElement, 'aria-hidden', 'true');
+  }
+}

--- a/projects/angular-ui/src/lib/file/file-intl.ts
+++ b/projects/angular-ui/src/lib/file/file-intl.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023 Ville de Montreal. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE file in the project root for full license information.
+ */
+
+import { Injectable, Optional, SkipSelf } from '@angular/core';
+import { Subject } from 'rxjs';
+
+/**
+ * To modify the labels and text displayed, create a new instance of BaoFileIntl and
+ * include it in a custom provider
+ */
+@Injectable({ providedIn: 'root' })
+export class BaoFileIntl {
+  /**
+   * Stream to emit from when labels are changed. Use this to notify components when the labels have
+   * changed after initialization.
+   */
+  readonly changes: Subject<void> = new Subject<void>();
+
+  /** The label for button in dropzone */
+  dropzoneButtonLabel = 'Parcourir';
+
+  /** The default dropzone instructions */
+  defaultDropzoneInstructions = 'ou déposer votre fichier ici';
+
+  /** Error message displayed when uploaded file is too large */
+  fileTooBigErrorMessage = 'La taille de ce fichier est trop grande';
+
+  /** Error message displayed when uploaded file has an invalid type */
+  invalidFileTypeErrorMessage = "Ce format de fichier n'est pas autorisé";
+}
+
+@Injectable()
+export class BaoFileIntlEnglish extends BaoFileIntl {
+  /** The label for button in dropzone */
+  dropzoneButtonLabel = 'Browse';
+
+  /** The default dropzone instructions */
+  defaultDropzoneInstructions = 'or drop your file here';
+
+  /** Error message displayed when uploaded file is too large */
+  fileTooBigErrorMessage = 'The size of this file is too large';
+
+  /** Error message displayed when uploaded file has an invalid type */
+  invalidFileTypeErrorMessage = 'The format of this file is unauthorized';
+}
+
+/** @docs-private */
+export function BAO_FILE_INTL_PROVIDER_FACTORY(parentIntl: BaoFileIntl) {
+  return parentIntl || new BaoFileIntl();
+}
+
+/** @docs-private */
+export const BAO_FILE_INTL_PROVIDER = {
+  // If there is already an BaoFileIntl available, use that. Otherwise, provide a new one.
+  provide: BaoFileIntl,
+  deps: [[new Optional(), new SkipSelf(), BaoFileIntl]],
+  useFactory: BAO_FILE_INTL_PROVIDER_FACTORY
+};

--- a/projects/angular-ui/src/lib/file/file-preview.component.html
+++ b/projects/angular-ui/src/lib/file/file-preview.component.html
@@ -1,0 +1,31 @@
+<div class="bao-file-info">
+  <ng-content select="bao-icon"></ng-content>
+  <bao-icon
+    *ngIf="insertGenericIcon && !thumbnailURL"
+    class="bao-file-media"
+    svgIcon="icon-file"
+  >
+  </bao-icon>
+  <ng-container *ngIf="thumbnailURL && !isLoading">
+    <img
+      class="bao-file-media"
+      [src]="thumbnailURL"
+      width="40px"
+      height="40px"
+    />
+  </ng-container>
+  <div class="bao-file-text">
+    <div class="bao-file-name">{{ file.name }}</div>
+    <div class="bao-file-size">{{ fileSize }}</div>
+  </div>
+</div>
+<ng-container *ngIf="!isLoading">
+  <ng-content select="button[bao-button]"></ng-content>
+  <ng-content select="baoDropdownTriggerFor"></ng-content>
+</ng-container>
+<bao-icon
+  *ngIf="isLoading"
+  class="loading-spinner"
+  svgIcon="icon-spinner"
+  title="chargement"
+></bao-icon>

--- a/projects/angular-ui/src/lib/file/file-preview.component.scss
+++ b/projects/angular-ui/src/lib/file/file-preview.component.scss
@@ -1,0 +1,46 @@
+@import '../core/colors';
+@import '../core/typography';
+
+.bao-file-preview {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 0.625rem;
+  padding-bottom: 0.625rem;
+  list-style-type: none;
+  &:first-child {
+    margin-top: 1rem;
+  }
+  > .bao-file-info {
+    display: flex;
+    align-items: center;
+    > .bao-icon {
+      color: $neutral-tertiary;
+      flex-shrink: 0;
+    }
+    > .bao-file-media {
+      margin-right: 1rem;
+    }
+    > .bao-file-text {
+      display: inline-flex;
+      flex-direction: column;
+      margin-right: 1rem;
+      > .bao-file-name {
+        overflow: hidden;
+        @include typo-interface-small-bold;
+        color: $ground-reversed;
+      }
+      > .bao-file-size {
+        @include typo-interface-xsmall;
+        color: $neutral-secondary;
+      }
+    }
+  }
+  .loading-spinner {
+    color: $action;
+  }
+  .bao-dropdown-menu-container {
+    position: absolute;
+    margin-left: auto;
+  }
+}

--- a/projects/angular-ui/src/lib/file/file-preview.component.spec.ts
+++ b/projects/angular-ui/src/lib/file/file-preview.component.spec.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023 Ville de Montreal. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE file in the project root for full license information.
+ */
+
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import {
+  TestFilePreviewHostComponent,
+  TestFilePreviewWithoutIconHostComponent
+} from './tests/file-preview.hostcomponent.spec';
+import { BaoFilePreviewComponent } from './file-preview.component';
+import { BaoIconComponent } from '../icon';
+import { BaoButtonComponent } from '../button';
+
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+describe('BaoFilePreviewComponent', () => {
+  let testComponent: TestFilePreviewHostComponent;
+  let fixture: ComponentFixture<TestFilePreviewHostComponent>;
+  let fixtureWithoutIcon: ComponentFixture<TestFilePreviewWithoutIconHostComponent>;
+  let filePreviewDebugElement: DebugElement;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [
+          BaoFilePreviewComponent,
+          BaoIconComponent,
+          BaoButtonComponent,
+          TestFilePreviewHostComponent,
+          TestFilePreviewWithoutIconHostComponent
+        ],
+        imports: [],
+        providers: []
+      });
+      return TestBed.compileComponents();
+    })
+  );
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestFilePreviewHostComponent);
+    fixtureWithoutIcon = TestBed.createComponent(
+      TestFilePreviewWithoutIconHostComponent
+    );
+    testComponent = fixture.componentInstance;
+    fixture.detectChanges();
+    fixtureWithoutIcon.detectChanges();
+    filePreviewDebugElement = fixture.debugElement.query(
+      By.css('bao-file-preview')
+    );
+  });
+  it('should create', () => {
+    expect(testComponent).toBeTruthy();
+  });
+  it('should replace button by loader when isLoading is true', () => {
+    const buttonElement = Array.from(
+      filePreviewDebugElement.nativeNode.children
+    ).find((el: Element) => el.classList.contains('bao-button'));
+    expect(buttonElement).toBeDefined();
+    testComponent.isLoading = true;
+    fixture.detectChanges();
+    const buttonElementOnLoading = Array.from(
+      filePreviewDebugElement.nativeNode.children
+    ).find((el: Element) => el.classList.contains('bao-button'));
+    expect(buttonElementOnLoading).toBeUndefined();
+    const loaderElement = Array.from(
+      filePreviewDebugElement.nativeNode.children
+    ).find((el: Element) => el.classList.contains('loading-spinner'));
+    expect(loaderElement).toBeDefined();
+  });
+  it('should not replace icon from projected content if there is one', () => {
+    const iconElement = fixture.debugElement.queryAll(By.css('.bao-icon'));
+    expect(iconElement.length).toBe(1);
+    expect(iconElement[0].nativeNode.attributes['svgicon'].value).toBe(
+      'icon-trash'
+    );
+  });
+  it('should set generic icon if projected content does not have icon', () => {
+    const iconElement = fixtureWithoutIcon.debugElement.queryAll(
+      By.css('.bao-icon')
+    );
+    expect(iconElement.length).toBe(1);
+    expect(iconElement[0].nativeNode.attributes['svgicon'].value).toBe(
+      'icon-file'
+    );
+  });
+});

--- a/projects/angular-ui/src/lib/file/file-preview.component.ts
+++ b/projects/angular-ui/src/lib/file/file-preview.component.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2023 Ville de Montreal. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE file in the project root for full license information.
+ */
+
+import {
+  AfterContentInit,
+  Component,
+  ElementRef,
+  Input,
+  Renderer2,
+  ViewEncapsulation
+} from '@angular/core';
+
+const KILO_THRESHOLD = 1000;
+const MEGA_THRESHOLD = 1000000;
+
+@Component({
+  selector: 'bao-file-preview, [bao-file-preview]',
+  templateUrl: './file-preview.component.html',
+  styleUrls: ['./file-preview.component.scss'],
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    class: 'bao-file-preview'
+  }
+})
+export class BaoFilePreviewComponent implements AfterContentInit {
+  /**
+   * Uploaded file to display in list.
+   */
+  @Input() public file: File;
+
+  /**
+   * Is file loading
+   */
+  @Input() public isLoading = false;
+
+  /**
+   * True if projected content has no icon and file does not have a thumbnail.
+   */
+  public insertGenericIcon = false;
+
+  public thumbnailURL = '';
+
+  constructor(
+    private elementRef: ElementRef<HTMLElement>,
+    private renderer: Renderer2
+  ) {}
+
+  get nativeElement(): HTMLElement {
+    return this.elementRef.nativeElement;
+  }
+
+  get fileSize(): string {
+    return this.formatSize(this.file.size);
+  }
+
+  ngAfterContentInit(): void {
+    this.getThumbnail();
+    this.setIcon();
+  }
+
+  private setIcon() {
+    // If no icon is in the projected content, generic icon is added
+    const contentIcon = Array.from(
+      this.nativeElement.children.item(0).children
+    ).find((el: HTMLElement) => el.localName === 'bao-icon');
+    if (!contentIcon) {
+      this.insertGenericIcon = true;
+    } else {
+      this.renderer.addClass(contentIcon, 'bao-file-media');
+    }
+  }
+
+  private getThumbnail() {
+    if (
+      this.file &&
+      (this.file.type === 'image/png' || this.file.type === 'image/jpeg')
+    ) {
+      const reader = new FileReader();
+      reader.onload = (event: any) => {
+        this.thumbnailURL = event.target.result;
+      };
+
+      reader.onerror = () => {
+        this.thumbnailURL = '';
+      };
+      reader.readAsDataURL(this.file);
+    }
+  }
+
+  private formatSize(size: number) {
+    if (size >= KILO_THRESHOLD && size / KILO_THRESHOLD < KILO_THRESHOLD) {
+      return this.getSizeAndUnit(size, KILO_THRESHOLD, 'Ko');
+    }
+    const sizeDividedByKoMultiplicator = size / KILO_THRESHOLD;
+    if (sizeDividedByKoMultiplicator >= KILO_THRESHOLD) {
+      const toFixed = sizeDividedByKoMultiplicator > 10 ? 0 : 1;
+      return this.getSizeAndUnit(size, MEGA_THRESHOLD, 'Mo', toFixed);
+    }
+    return `${size} octets`;
+  }
+
+  private getSizeAndUnit(
+    size: number,
+    multiplicator: number,
+    unit: string,
+    toFixed = 0
+  ): string {
+    return `${(size / multiplicator).toFixed(toFixed)} ${unit}`;
+  }
+}

--- a/projects/angular-ui/src/lib/file/index.ts
+++ b/projects/angular-ui/src/lib/file/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2023 Ville de Montreal. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE file in the project root for full license information.
+ */
+export * from './module';
+export * from './file-input.component';
+export * from './file-preview.component';
+export * from './file-intl';

--- a/projects/angular-ui/src/lib/file/module.ts
+++ b/projects/angular-ui/src/lib/file/module.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 Ville de Montreal. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE file in the project root for full license information.
+ */
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import {
+  BaoFileInputComponent,
+  BaoFileDropDirective,
+  BaoFileDropzoneIntructions
+} from './file-input.component';
+import { BaoFilePreviewComponent } from './file-preview.component';
+import { BAO_FILE_INTL_PROVIDER } from './file-intl';
+import { BaoButtonModule } from '../button';
+import { BaoIconModule } from '../icon';
+import { BaoDropdownMenuModule } from '../dropdown-menu';
+import { BaoCommonComponentsModule } from '../common-components';
+
+const FILE_DIRECTIVES = [
+  BaoFileInputComponent,
+  BaoFileDropzoneIntructions,
+  BaoFileDropDirective,
+  BaoFilePreviewComponent
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    BaoDropdownMenuModule,
+    BaoCommonComponentsModule,
+    BaoIconModule,
+    BaoButtonModule
+  ],
+  declarations: [FILE_DIRECTIVES],
+  exports: [FILE_DIRECTIVES],
+  providers: [BAO_FILE_INTL_PROVIDER]
+})
+export class BaoFileModule {}

--- a/projects/angular-ui/src/lib/file/tests/file-input.hostcomponent.spec.ts
+++ b/projects/angular-ui/src/lib/file/tests/file-input.hostcomponent.spec.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Ville de Montreal. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE file in the project root for full license information.
+ */
+
+import { Component } from '@angular/core';
+
+@Component({
+  template: `
+    <bao-file-input
+      [disabled]="disabled"
+      [label]="label"
+      [size]="size"
+      [required]="required"
+      [maximalFileSize]="maximalFileSize"
+      [acceptedMIMETypes]="acceptedMIMETypes"
+    >
+      <bao-guiding-text
+        >Les documents .pdf, .docx, .png sont acceptés</bao-guiding-text
+      >
+    </bao-file-input>
+  `
+})
+export class TestFileInputHostComponent {
+  disabled: boolean;
+  label: string;
+  size: 'small' | 'medium';
+  required: boolean;
+  maximalFileSize: number;
+  acceptedMIMETypes: string[];
+}

--- a/projects/angular-ui/src/lib/file/tests/file-preview.hostcomponent.spec.ts
+++ b/projects/angular-ui/src/lib/file/tests/file-preview.hostcomponent.spec.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023 Ville de Montreal. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE file in the project root for full license information.
+ */
+
+import { Component } from '@angular/core';
+
+@Component({
+  template: `
+    <bao-file-preview [file]="file" [isLoading]="isLoading">
+      <bao-icon svgIcon="icon-trash"></bao-icon>
+      <button bao-button type="editorial" level="tertiary" size="medium">
+        Supprimer
+      </button>
+    </bao-file-preview>
+  `
+})
+export class TestFilePreviewHostComponent {
+  file = new File([''], 'testFile', { type: 'text/html' });
+  isLoading: boolean;
+}
+@Component({
+  template: `
+    <bao-file-preview [file]="file" [isLoading]="isLoading">
+      <button bao-button type="editorial" level="tertiary" size="medium">
+        Supprimer
+      </button>
+    </bao-file-preview>
+  `
+})
+export class TestFilePreviewWithoutIconHostComponent {
+  file = new File([''], 'testFile', { type: 'text/html' });
+  isLoading: boolean;
+}

--- a/projects/angular-ui/src/public-api.ts
+++ b/projects/angular-ui/src/public-api.ts
@@ -23,3 +23,4 @@ export * from './lib/tabs';
 export * from './lib/modal';
 export * from './lib/hyperlink';
 export * from './lib/dropdown-menu';
+export * from './lib/file';

--- a/projects/storybook-angular-examples/src/app/file/file-example.component.html
+++ b/projects/storybook-angular-examples/src/app/file/file-example.component.html
@@ -1,0 +1,54 @@
+<div style="max-width: 22rem">
+  <form [formGroup]="fileInputForm">
+    <bao-file-input
+      formControlName="fileList"
+      label="Formulaire de déclaration"
+      required="true"
+      (uploadedFile)="onUploadedFile($event)"
+    >
+      <bao-guiding-text
+        >Les documents .pdf, .docx, .png sont acceptés</bao-guiding-text
+      >
+      <ul *ngIf="fileList.value.length">
+        <ng-container
+          *ngFor="let uploadedFile of fileList.value; let i = index"
+        >
+          <li bao-file-preview [file]="uploadedFile">
+            <button
+              bao-button
+              type="editorial"
+              level="tertiary"
+              size="medium"
+              (click)="onDelete(i)"
+            >
+              <bao-icon svgIcon="icon-trash"></bao-icon>
+            </button>
+          </li>
+        </ng-container>
+      </ul>
+      <bao-error *ngIf="fileList.dirty && fileList.errors?.['required']">
+        Un formulaire doit être sélectionné
+      </bao-error>
+    </bao-file-input>
+    <button
+      bao-button
+      type="button"
+      displayType="utility"
+      level="primary"
+      [disabled]="!fileInputForm.valid"
+      style="margin-top: 1.5rem"
+      (click)="onSubmitButtonClick()"
+    >
+      Soumettre
+    </button>
+  </form>
+  <div *ngIf="lastUploadedFiles" style="margin-top: 1rem">
+    Derniers fichiers téléversés :
+    <p
+      *ngFor="let file of lastUploadedFiles"
+      style="font-weight: bold; margin-bottom: 0"
+    >
+      {{ file }}
+    </p>
+  </div>
+</div>

--- a/projects/storybook-angular-examples/src/app/file/file-example.component.ts
+++ b/projects/storybook-angular-examples/src/app/file/file-example.component.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Ville de Montreal. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE file in the project root for full license information.
+ */
+
+import { ChangeDetectorRef, Component } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+
+/**
+ * @title Reactive form file input
+ */
+@Component({
+  selector: 'bao-file-form-example',
+  templateUrl: './file-example.component.html'
+})
+export class BaoFileReactiveFormExampleComponent {
+  public fileInputForm: FormGroup;
+  public lastUploadedFiles: File[];
+
+  constructor(fb: FormBuilder, private cdr: ChangeDetectorRef) {
+    this.fileInputForm = fb.group({
+      fileList: [[], [Validators.required]]
+    });
+    this.fileInputForm.valueChanges.subscribe(() => this.cdr.detectChanges());
+  }
+
+  get fileList() {
+    return this.fileInputForm.get('fileList');
+  }
+
+  public onSubmitButtonClick(): void {
+    this.lastUploadedFiles = this.fileInputForm
+      .getRawValue()
+      .fileList.map((file: File) => file.name);
+    this.fileList.reset([]);
+    this.fileInputForm.markAsPristine();
+  }
+
+  public onUploadedFile(file: File): void {
+    this.fileList.value.push(file);
+  }
+
+  public onDelete(index: number): void {
+    this.fileList.value.splice(index, 1);
+  }
+}

--- a/projects/storybook-angular/src/stories/File/FileInput.stories.ts
+++ b/projects/storybook-angular/src/stories/File/FileInput.stories.ts
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) 2023 Ville de Montreal. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE file in the project root for full license information.
+ */
+import { CommonModule } from '@angular/common';
+import { moduleMetadata } from '@storybook/angular';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { PortalModule } from '@angular/cdk/portal';
+import { ReactiveFormsModule } from '@angular/forms';
+import { Meta, Story } from '@storybook/angular/types-6-0';
+import {
+  BaoFileInputComponent,
+  BaoFileDropzoneIntructions,
+  BaoFileDropDirective,
+  BaoGuidingTextComponent,
+  BaoButtonComponent,
+  BaoLabelTextComponent,
+  BaoErrorTextComponent,
+  BaoIconComponent,
+  BaoFilePreviewComponent,
+  BaoDropdownMenuComponent,
+  BaoDropdownMenuTrigger,
+  BaoDropdownMenuItemLabel,
+  BaoDropdownMenuItem
+} from 'angular-ui';
+import { BaoFileReactiveFormExampleComponent } from 'projects/storybook-angular-examples/src/app/file/file-example.component';
+
+const description = `
+The File Input component allows users to transfer local files to the system. 
+
+## Documentation
+The full documentation of this component is available in the Hochelaga design system documentation under "[Fichier](https://zeroheight.com/575tugn0n/p/26da67)".
+`;
+
+export default {
+  title: 'Components/File/Selector',
+  decorators: [
+    moduleMetadata({
+      declarations: [
+        BaoFileInputComponent,
+        BaoFileDropzoneIntructions,
+        BaoFileDropDirective,
+        BaoGuidingTextComponent,
+        BaoButtonComponent,
+        BaoLabelTextComponent,
+        BaoErrorTextComponent,
+        BaoIconComponent,
+        BaoFilePreviewComponent,
+        BaoFileReactiveFormExampleComponent,
+        BaoDropdownMenuComponent,
+        BaoDropdownMenuTrigger,
+        BaoDropdownMenuItemLabel,
+        BaoDropdownMenuItem
+      ],
+      imports: [CommonModule, OverlayModule, PortalModule, ReactiveFormsModule]
+    })
+  ],
+  component: BaoFileInputComponent,
+  parameters: {
+    docs: {
+      description: {
+        component: description
+      }
+    }
+  },
+  argTypes: {
+    ngAfterContentInit: {
+      table: {
+        disable: true
+      }
+    },
+    uploadFile: {
+      table: {
+        disable: true
+      }
+    },
+    _intlChanges: {
+      table: {
+        disable: true
+      }
+    },
+    _value: {
+      table: {
+        disable: true
+      }
+    },
+    insertDefaultInstructions: {
+      table: {
+        disable: true
+      }
+    },
+    intl: {
+      table: {
+        disable: true
+      }
+    },
+    isFileTooBig: {
+      table: {
+        disable: true
+      }
+    },
+    isFileTypeInvalid: {
+      table: {
+        disable: true
+      }
+    },
+    propagateChange: {
+      table: {
+        disable: true
+      }
+    },
+    propagateTouched: {
+      table: {
+        disable: true
+      }
+    },
+    uploadedFile: {
+      table: {
+        disable: true
+      }
+    },
+    ngOnDestroy: {
+      table: {
+        disable: true
+      }
+    },
+    registerOnChange: {
+      table: {
+        disable: true
+      }
+    },
+    registerOnTouched: {
+      table: {
+        disable: true
+      }
+    },
+    setDisabledState: {
+      table: {
+        disable: true
+      }
+    },
+    setValue: {
+      table: {
+        disable: true
+      }
+    },
+    writeValue: {
+      table: {
+        disable: true
+      }
+    },
+    uploader: {
+      table: {
+        disable: true
+      }
+    },
+    _files: {
+      table: {
+        disable: true
+      }
+    },
+    _errorTexts: {
+      table: {
+        disable: true
+      }
+    },
+    _errorForm: {
+      table: {
+        disable: true
+      }
+    },
+    ngAfterViewInit: {
+      table: {
+        disable: true
+      }
+    },
+    setDescribedByAttribute: {
+      table: {
+        disable: true
+      }
+    },
+    setErrorTextsAttribute: {
+      table: {
+        disable: true
+      }
+    },
+    _helperTextId: {
+      table: {
+        disable: true
+      }
+    },
+    enterKeyEvent: {
+      table: {
+        disable: true
+      }
+    },
+    shiftTabKeyEvent: {
+      table: {
+        disable: true
+      }
+    },
+    tabKeyEvent: {
+      table: {
+        disable: true
+      }
+    },
+    dropzoneElement: {
+      table: {
+        disable: true
+      }
+    }
+  }
+} as Meta;
+
+const Template: Story<BaoFileInputComponent> = (
+  args: BaoFileInputComponent
+) => ({
+  component: BaoFileInputComponent,
+  template: `
+    <div style="max-width:24rem;">
+      <bao-file-input [disabled]="disabled" [label]="label" [size]="size" [required]="required" [maximalFileSize]="maximalFileSize" [acceptedMIMETypes]="acceptedMIMETypes">
+        <bao-guiding-text>Les documents .pdf, .docx, .png sont acceptés</bao-guiding-text>
+        <bao-file-dropzone-instructions> ou deposer votre [elt] ici</bao-file-dropzone-instructions>
+      </bao-file-input>
+    </div>
+   `,
+  props: args
+});
+
+export const Primary = Template.bind({});
+
+Primary.args = {
+  label: 'Libellé',
+  size: 'medium',
+  required: true,
+  disabled: false,
+  acceptedMIMETypes: ['application/pdf', 'image/jpg', 'image/jpeg', 'image/png']
+};
+
+export const baoFileIntl: Story = args => ({
+  props: args,
+  template: `
+      <div style="max-width:50rem;">
+        <p> By default, the File Input component displays its texts in french. To display text in another language, here are the steps to follow:
+        <ol>
+          <li> In your <b>app.module.ts</b>, import <b>BaoFileIntl</b> and <b>BaoFileIntlEnglish</b> for texts in english from @villedemontreal/angular-ui. </li>
+          <li> If you need to use the component in a different language, you can declare your own class that extends BaoFileIntl and contains texts in your prefered language. It should look like this:
+            <p> 
+              <code>@Injectable()<br>
+                    class BaoFileIntlEnglish extends BaoFileIntl {{ '{' }}
+                    <div style="margin-left:1rem;font-family:inherit;font-size:inherit;">
+                      dropzoneButtonLabel = 'Browse';<br>
+                      defaultDropzoneInstructions = 'or drop your file here';<br>
+                      fileTooBigErrorMessage = 'The size of this file is too large';<br>
+                      invalidFileTypeErrorMessage = 'The format of this file is unauthorized';<br>
+                    </div>
+                  {{ '}' }}
+              </code>
+            </p>
+          </li>
+          <li>In the providers of your app's module, add this line:<br>
+            <code> providers: [{{ '{' }}provide: BaoFileIntl, useClass: BaoFileIntlEnglish{{ '}' }}]</code> 
+          </li>
+          <li> And that's it, the content of the component should now be in your preferedd language!</li>
+        </ol>
+      </div>
+  `
+});
+baoFileIntl.storyName = 'BAOFileIntl - Translating the File Input component';
+baoFileIntl.args = {
+  ...Primary.args
+};
+
+export const fileInputDeactivated: Story = args => ({
+  props: args,
+  template: `
+      <div style="max-width:24rem;">
+        <bao-file-input disabled="true" [label]="label">
+          <bao-guiding-text>Les documents .pdf, .docx, .png sont acceptés</bao-guiding-text>
+          <bao-file-dropzone-instructions> ou déposer votre [elt] ici</bao-file-dropzone-instructions>
+        </bao-file-input>
+      </div>
+  `
+});
+fileInputDeactivated.storyName = 'File input deactivated';
+fileInputDeactivated.args = {
+  ...Primary.args
+};
+
+export const fileInputForm: Story = args => ({
+  props: args,
+  template: `
+    <bao-file-form-example></bao-file-form-example>
+  `
+});
+fileInputForm.storyName = 'File input reactive form';
+fileInputForm.args = {
+  ...Primary.args
+};

--- a/projects/storybook-angular/src/stories/File/FilePreview.stories.ts
+++ b/projects/storybook-angular/src/stories/File/FilePreview.stories.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2023 Ville de Montreal. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE file in the project root for full license information.
+ */
+import { CommonModule } from '@angular/common';
+import { moduleMetadata } from '@storybook/angular';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { PortalModule } from '@angular/cdk/portal';
+import { Meta, Story } from '@storybook/angular/types-6-0';
+import {
+  BaoFilePreviewComponent,
+  BaoDropdownMenuComponent,
+  BaoDropdownMenuTrigger,
+  BaoDropdownMenuItem,
+  BaoDropdownMenuItemLabel,
+  BaoButtonComponent,
+  BaoIconComponent
+} from 'angular-ui';
+
+const description = `
+The File component allows users to transfer local files to the system. 
+
+## Documentation
+The full documentation of this component is available in the Hochelaga design system documentation under "[Fichier](https://zeroheight.com/575tugn0n/p/26da67)".
+`;
+
+export default {
+  title: 'Components/File/Preview',
+  decorators: [
+    moduleMetadata({
+      declarations: [
+        BaoFilePreviewComponent,
+        BaoDropdownMenuComponent,
+        BaoDropdownMenuTrigger,
+        BaoDropdownMenuItem,
+        BaoDropdownMenuItemLabel,
+        BaoButtonComponent,
+        BaoIconComponent
+      ],
+      imports: [CommonModule, OverlayModule, PortalModule]
+    })
+  ],
+  component: BaoFilePreviewComponent,
+  parameters: {
+    docs: {
+      description: {
+        component: description
+      }
+    }
+  },
+  argTypes: {
+    ngAfterContentInit: {
+      table: {
+        disable: true
+      }
+    },
+    insertGenericIcon: {
+      table: {
+        disable: true
+      }
+    },
+    thumbnailURL: {
+      table: {
+        disable: true
+      }
+    },
+    formatSize: {
+      table: {
+        disable: true
+      }
+    },
+    getSizeAndUnit: {
+      table: {
+        disable: true
+      }
+    },
+    getThumbnail: {
+      table: {
+        disable: true
+      }
+    },
+    setIcon: {
+      table: {
+        disable: true
+      }
+    }
+  }
+} as Meta;
+
+const Template: Story<BaoFilePreviewComponent> = (
+  args: BaoFilePreviewComponent
+) => ({
+  component: BaoFilePreviewComponent,
+  template: `
+    <div style="max-width:20rem;">
+      <bao-file-preview [file]="file" [isLoading]="isLoading">
+        <bao-icon svgIcon="icon-file"></bao-icon>
+        <button bao-button type="editorial" level="tertiary" size="medium">
+          <bao-icon svgIcon="icon-trash"></bao-icon>
+        </button>
+      </bao-file-preview>
+    </div>
+   `,
+  props: args
+});
+
+export const Primary = Template.bind({});
+
+Primary.args = {
+  file: {
+    name: 'sample.pdf',
+    size: 55555,
+    lastModified: 1669754503525,
+    type: 'application/pdf',
+    webkitRelativePath: ''
+  },
+  isLoading: false
+};
+
+export const filePreviewWithMenu: Story = args => ({
+  props: args,
+  template: `
+      <div style="max-width:20rem;">
+        <bao-file-preview [file]="file">
+          <bao-icon svgIcon="icon-file"></bao-icon>
+          <button bao-button [baoDropdownMenuTriggerFor]="testMenu" type="editorial" level="tertiary" 
+            size="medium">
+              <bao-icon svgIcon="icon-more-vertical"></bao-icon>
+          </button>
+          <bao-dropdown-menu #testMenu>
+            <ul>
+              <li>
+                <a bao-dropdown-menu-item>
+                  <bao-icon svgIcon="icon-trash"></bao-icon>
+                  <bao-dropdown-menu-item-label>Delete</bao-dropdown-menu-item-label>
+                </a>
+              </li>   
+              <li>
+                <a bao-dropdown-menu-item>
+                  <bao-icon svgIcon="icon-edit"></bao-icon>
+                  <bao-dropdown-menu-item-label>Rename</bao-dropdown-menu-item-label>
+                </a>
+              </li>
+            </ul>
+          </bao-dropdown-menu>
+        </bao-file-preview>
+      </div>
+  `
+});
+filePreviewWithMenu.storyName = 'File preview with dropdown menu';
+filePreviewWithMenu.args = {
+  ...Primary.args
+};


### PR DESCRIPTION
Ajout de la composante de téléversement de fichier. À noter que cette composante a été décomposée en deux composantes indépendantes, soit le sélecteur de fichier (bao-input-file) et le bao-file-preview pour afficher une liste de fichiers téléversés.

![bao_file_input1](https://user-images.githubusercontent.com/33531625/208186951-b04b2753-9d27-4c42-9192-608352038071.PNG)

![bao_file_input2](https://user-images.githubusercontent.com/33531625/208186959-1300413a-c746-4618-a3e3-7a60c02d9464.PNG)

![bao_file_preview](https://user-images.githubusercontent.com/33531625/208186966-d9761df5-9004-4e09-ab6d-96aa2f0ab48e.PNG)
