### PR TITLE
chore: fix jenkins build where watcher need python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:16.14-alpine
 LABEL MAINTAINER="VdMtl" 
 
 # Create app directory
@@ -10,10 +10,10 @@ WORKDIR /usr/src/lib
 COPY --chown=node:node . /usr/src/lib
 
 # Install deps
-RUN npm i
+RUN npm ci --ignore-scripts
 
 # Build library
-RUN npm run build 
+RUN npm run build-storybook 
 
 # Publish the library
 CMD ["npm", "publish", "dist/angular-ui", "--tag", "latest", "--unsafe-perm"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ sbCtx = pipeline.createContext([
             // ],
             [
                 name: "nodejs",
-                image: "node:16.13.2-alpine",
+                image: "node:16.14-alpine",
                 ttyEnabled: true,
                 command: "cat",
             ],
@@ -131,7 +131,7 @@ pipeline.start(sbCtx) {
         pipeline.buildStage(sbCtx) {
             // first, regen the static web assets used by the Hugo site
             container("nodejs") {
-                sh "npm ci"
+                sh "npm ci --ignore-scripts"
                 sh "npm run build-storybook"
             }
             // finally, build the image


### PR DESCRIPTION
Le build sur jenkins fail.

Il semblerait que @parcel/watcher à besoin de python pour recompiler la librairie et alpine n'a pas python. Il y a aussi des warnings comme quoi la version minimal est node-16.14 et on était à la version 16.13

j'ai désactiver les scripts sur le post install pour ne pas avoir besoin de recompiler car dans le cadre de la publication de la librairie, on n'a pas besoin de ces dependances.