### PR TITLE
feat: CRMMON-8778 add ally to hide toast

### DIFF
--- a/projects/angular-ui/global.scss
+++ b/projects/angular-ui/global.scss
@@ -1,5 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,300;1,400;1,600;1,700;1,800');
 @import '@angular/cdk/overlay-prebuilt.css';
+@import '@angular/cdk/a11y-prebuilt.css';
 
 * {
   font-family: 'Open Sans', Helvetica, Arial, sans-serif;


### PR DESCRIPTION
This was added in `master-17`, not in `master-15`
We want to avoid showing the extra div below :

https://github.com/user-attachments/assets/8ee510bf-7f22-4e2b-8fad-e2ff59af7f7e

result : 

https://github.com/user-attachments/assets/15ddaee3-b6bc-4582-ae3a-7128d58a99e3

The labels are **not** the ones that are gonna be used
